### PR TITLE
Add E_enumerate report event

### DIFF
--- a/src/lib/report/atomic_event.ml
+++ b/src/lib/report/atomic_event.ml
@@ -28,6 +28,7 @@ type ('term, 'fn, 'var, 'ty) poly =
   | E_refuted_by_smt of
       'term * ('term, 'fn, 'var, 'ty) Imandrax_api_model.t option
   | E_fun_expansion of 'term * 'term (* TODO: generalize, elim, etc. *)
+  | E_enumerate of string list
 [@@deriving show { with_path = false }, twine, typereg, map]
 
 type t =


### PR DESCRIPTION
For https://github.com/imandra-ai/imandrax/pull/705

I'm not sure we should keep growing this list. It may be better to put simple things (like this) into an `E_message`.