### PR TITLE
chore(py): bump version

### DIFF
--- a/src/py/setup.py
+++ b/src/py/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.7.1b1"
+VERSION = "0.8"
 setup(
     name="imandrax_api",
     version=VERSION,


### PR DESCRIPTION
Follow on from 24cc7f3dcc2807bfea32aadf205b656a1f3bf123.

I assume that the convention is that the Python minor version follows the API types version?

Note that this will soon be published to PyPI so we need to do this as part of the release/update process.