### PR TITLE
fix(to_iml): printing fixes

### DIFF
--- a/src/ppx/cir/imandrax_api_ppx_cir.ml
+++ b/src/ppx/cir/imandrax_api_ppx_cir.ml
@@ -130,7 +130,7 @@ let rec expr_of_cir (ty : core_type) (e : expression) : expression =
       | _ -> failwith "of-cir: expected tuple"]
   | { ptyp_desc = Ptyp_alias (ty, _); _ } -> expr_of_cir ty e
   | { ptyp_desc = Ptyp_variant _; ptyp_loc = loc; _ } ->
-    [%expr [%error "Cannot register polymorphic variants yet"]]
+    [%expr [%error "Cannot register polymorphic variants"]]
   | { ptyp_desc = Ptyp_arrow _; ptyp_loc = loc; _ } ->
     [%expr [%error "Cannot register functions"]]
   | { ptyp_desc = Ptyp_class _ | Ptyp_object _; ptyp_loc = loc; _ } ->

--- a/src/ppx/to-iml/imandrax_api_ppx_to_iml.ml
+++ b/src/ppx/to-iml/imandrax_api_ppx_to_iml.ml
@@ -98,7 +98,7 @@ let rec expr_to_iml (ty : core_type) (e : expression) : expression =
       Printf.sprintf "(%s)" (String.concat ", " items)]
   | { ptyp_desc = Ptyp_alias (ty, _); _ } -> expr_to_iml ty e
   | { ptyp_desc = Ptyp_variant _; ptyp_loc = loc; _ } ->
-    [%expr [%error "Cannot turn to iml polymorphic variants yet"]]
+    [%expr [%error "Cannot turn to iml polymorphic variants"]]
   | { ptyp_desc = Ptyp_arrow _; ptyp_loc = loc; _ } ->
     [%expr [%error "Cannot turn to iml functions"]]
   | { ptyp_desc = Ptyp_class _ | Ptyp_object _; ptyp_loc = loc; _ } ->


### PR DESCRIPTION
further fixes to the `to_iml` deriver after inspecting the codegen via `@@deriving_inline`