### PR TITLE
Improve Twirp errors

### DIFF
--- a/src/py/twirp/errors.py
+++ b/src/py/twirp/errors.py
@@ -1,6 +1,7 @@
-from enum import Enum
+from enum import StrEnum
 
-class Errors(Enum):
+
+class Errors(StrEnum):
     Canceled = "canceled"
     Unknown = "unknown"
     InvalidArgument = "invalid_argument"
@@ -44,4 +45,3 @@ class Errors(Enum):
             Errors.DataLoss: 500,
             Errors.NoError: 200,
         }.get(code, 500)
-

--- a/src/py/twirp/exceptions.py
+++ b/src/py/twirp/exceptions.py
@@ -21,7 +21,7 @@ class TwirpServerException(httplib.HTTPException):
             self._code = errors.Errors.Unknown
         self._message = message
         self._meta = meta
-        super(TwirpServerException, self).__init__(message)
+        super(TwirpServerException, self).__init__(message, meta)
 
     @property
     def code(self):


### PR DESCRIPTION
- Include `meta` in `Exception` init args, so users see error response bodies in default exception printers (rather than just seeing `BadRequest`)
- Handle API version mismatch explicitly, presenting better message to user