### PR TITLE
Respect optionality of async client in Python

### DIFF
--- a/src/py/bindings/api_twirp.py
+++ b/src/py/bindings/api_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/artmsg_twirp.py
+++ b/src/py/bindings/artmsg_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/error_twirp.py
+++ b/src/py/bindings/error_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/locs_twirp.py
+++ b/src/py/bindings/locs_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/session_twirp.py
+++ b/src/py/bindings/session_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/simple_api_twirp.py
+++ b/src/py/bindings/simple_api_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/system_twirp.py
+++ b/src/py/bindings/system_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/task_twirp.py
+++ b/src/py/bindings/task_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/bindings/utils_twirp.py
+++ b/src/py/bindings/utils_twirp.py
@@ -8,7 +8,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/protoc-gen-twirpy/generator/template.go
+++ b/src/py/protoc-gen-twirpy/generator/template.go
@@ -39,7 +39,7 @@ from ..twirp.client import TwirpClient
 try:
 	from ..twirp.async_client import AsyncTwirpClient
 	_async_available = True
-except ModuleNotFoundError:
+except ImportError:
 	_async_available = False
 
 _sym_db = _symbol_database.Default()

--- a/src/py/twirp/async_client.py
+++ b/src/py/twirp/async_client.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from typing import Optional
 
 from . import exceptions
 from . import errors


### PR DESCRIPTION
Catch a more general `ImportError`
Testing working locally (without optional `async` extra)