### PR TITLE
fix missing wsclient when vscode bin path is hardcoded

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -313,6 +313,8 @@ macos_install() {
   # modify executable to find libs
   sed -i'.backup' "s#DIR=/opt/imandrax#DIR=${INSTALL_PREFIX}/opt/imandrax#" \
     "${INSTALL_PREFIX}/bin/imandrax-cli"
+  sed -i'.backup' "s#export PATH=\"\$PATH:\$DIR\"#BIN_DIR=${BIN_DIR}\nexport PATH=\"\$PATH:\$DIR\:\$BIN_DIR\"#" \
+    "${INSTALL_PREFIX}/bin/imandrax-cli"
   
   # clean up temp files
   rm -rf "${INSTALL_PREFIX}/bin/imandrax-cli.backup"


### PR DESCRIPTION
# description

There's a bug when installing ImandraX in VSCode where the user's environment is incorrectly detected, which results in the installer incorrectly updating the path in .profile instead of .zprofile.

I think the solution the team agreed on was to forget about the path and just hardcode the location of the imandrax-cli entry script in VSCode.

imandrax-cli still needs imandrax-ws-client to be on the PATH to work, so this PR updates the installer to update the path in the imandrax-cli entry script.

This bug only affects MacOS, so the change is only made for MacOS.

# testing

Deleted .profile and .zprofile and was still able to use the extension.

# issue

Improves user experience around but does not fix https://github.com/imandra-ai/imandrax-vscode/issues/54