### PR TITLE
Fix PyPi build

### DIFF
--- a/src/py/pyproject.toml
+++ b/src/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imandrax_api"
-version = "0.17.2"
+version = "0.17.2.1"
 description = "Imandrax API client library"
 requires-python = ">=3.12"
 dependencies = ["protobuf>=5.29.4,<6.0", "requests", "structlog"]
@@ -13,7 +13,7 @@ dependencies = ["protobuf>=5.29.4,<6.0", "requests", "structlog"]
 async = ["aiohttp"]
 
 [tool.setuptools]
-packages = ["imandrax_api"]
+packages = [ "imandrax_api", "imandrax_api.bindings", "imandrax_api.lib", "imandrax_api.twirp" ]
 package-dir = { "imandrax_api" = "." }
 
 [tool.uv]

--- a/src/py/pyproject.toml
+++ b/src/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imandrax_api"
-version = "0.17.0"
+version = "0.17.2"
 description = "Imandrax API client library"
 requires-python = ">=3.12"
 dependencies = ["protobuf>=5.29.4,<6.0", "requests", "structlog"]

--- a/src/py/setup.py
+++ b/src/py/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.17.2"
+VERSION = "0.17.2.1"
 setup(
     name="imandrax_api",
     version=VERSION,

--- a/src/py/setup.py
+++ b/src/py/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.17"
+VERSION = "0.17.2"
 setup(
     name="imandrax_api",
     version=VERSION,


### PR DESCRIPTION
The Python package build did not include some of the required sub-directories, so they are now added back.

@seprov @hon-gyu: if you intend to use `uv` for package publication please open a PR with updated PyPi publishing targets in the Makefile. The current setup does pick up the new `pyproject.toml` file, but apparently this behaves differently from the previous setup. (I fixed the directories, but there may well be other problems now.)