### PR TITLE
Py/client: re-open session via rpc if id is provided, fallback to create new

### DIFF
--- a/src/py/client/__init__.py
+++ b/src/py/client/__init__.py
@@ -48,6 +48,7 @@ class Client:
         api_key: str | None = None,
         timeout: int = 30,
         session_id: str | None = None,
+        create_if_not_found: bool = False,
     ) -> None:
         # use a session to help with cookies. See https://requests.readthedocs.io/en/latest/user/advanced/#session-objects
         self._session = requests.Session()
@@ -111,7 +112,7 @@ class Client:
                     timeout=timeout,
                 )
             except TwirpServerException as ex:
-                if is_session_not_found(ex):
+                if is_session_not_found(ex) and create_if_not_found:
                     self._sesh = self._client.create_session(
                         ctx=self.mk_context(),
                         request=simple_api_pb2.SessionCreateReq(

--- a/src/py/client/__init__.py
+++ b/src/py/client/__init__.py
@@ -10,6 +10,7 @@ from ..bindings import (
     api_pb2,
     api_twirp,
     session_pb2,
+    session_twirp,
     simple_api_pb2,
     simple_api_twirp,
     task_pb2,
@@ -18,7 +19,7 @@ from ..bindings import (
 from ..twirp.context import Context
 from ..twirp.errors import Errors
 from ..twirp.exceptions import TwirpServerException
-from ._common import mk_context, url_dev, url_prod
+from ._common import is_session_not_found, mk_context, url_dev, url_prod
 
 if TYPE_CHECKING:
     from ._async import AsyncClient
@@ -31,6 +32,7 @@ __all__ = ["Client", "AsyncClient", "url_dev", "url_prod"]
 class Client:
     _client: simple_api_twirp.SimpleClient
     _api_client: api_twirp.EvalClient
+    _session_mgr: session_twirp.SessionManagerClient
     _timeout: float
     _sesh: session_pb2.Session
 
@@ -56,6 +58,12 @@ class Client:
         self._url = url
         self._server_path_prefix = server_path_prefix
         self._client = simple_api_twirp.SimpleClient(
+            url,
+            timeout=timeout,
+            server_path_prefix=server_path_prefix,
+            session=self._session,
+        )
+        self._session_mgr = session_twirp.SessionManagerClient(
             url,
             timeout=timeout,
             server_path_prefix=server_path_prefix,
@@ -89,10 +97,30 @@ class Client:
                 else:
                     raise ex
         else:
-            # TODO: actually re-open session via RPC
-            self._sesh = session_pb2.Session(
-                id=session_id,
-            )
+            # Reopen the supplied session via the SessionManager.open_session
+            # RPC. If the server reports it as missing/expired, fall back to
+            # creating a fresh session.
+            self._sesh = session_pb2.Session(id=session_id)
+            try:
+                self._session_mgr.open_session(
+                    ctx=self.mk_context(),
+                    request=session_pb2.SessionOpen(
+                        id=self._sesh,
+                        api_version=api_types_version.api_types_version,
+                    ),
+                    timeout=timeout,
+                )
+            except TwirpServerException as ex:
+                if is_session_not_found(ex):
+                    self._sesh = self._client.create_session(
+                        ctx=self.mk_context(),
+                        request=simple_api_pb2.SessionCreateReq(
+                            api_version=api_types_version.api_types_version
+                        ),
+                        timeout=timeout,
+                    )
+                else:
+                    raise
 
     def __enter__(self, *_: Any) -> Client:
         return self

--- a/src/py/client/_async.py
+++ b/src/py/client/_async.py
@@ -29,6 +29,7 @@ class AsyncClient:
     _timeout: float
     _sesh: session_pb2.Session
     _session_id: str | None
+    _create_if_not_found: bool
 
     @staticmethod
     def mk_context() -> Context:
@@ -42,10 +43,12 @@ class AsyncClient:
         api_key: str | None = None,
         timeout: int = 30,
         session_id: str | None = None,
+        create_if_not_found: bool = False,
     ) -> None:
         # use a session to help with cookies. See https://requests.readthedocs.io/en/latest/user/advanced/#session-objects
         self._session: aiohttp.ClientSession = aiohttp.ClientSession()
         self._session_id = session_id
+        self._create_if_not_found = create_if_not_found
         self._closed = False
         self._auth_token = api_key if api_key else auth_token
         if self._auth_token:
@@ -102,7 +105,7 @@ class AsyncClient:
                     ),
                 )
             except TwirpServerException as ex:
-                if is_session_not_found(ex):
+                if is_session_not_found(ex) and self._create_if_not_found:
                     self._sesh = await self._client.create_session(
                         ctx=self.mk_context(),
                         request=simple_api_pb2.SessionCreateReq(

--- a/src/py/client/_async.py
+++ b/src/py/client/_async.py
@@ -10,6 +10,7 @@ from ..bindings import (
     api_pb2,
     api_twirp_async,
     session_pb2,
+    session_twirp_async,
     simple_api_pb2,
     simple_api_twirp_async,
     task_pb2,
@@ -18,12 +19,13 @@ from ..bindings import (
 from ..twirp.context import Context
 from ..twirp.errors import Errors
 from ..twirp.exceptions import TwirpServerException
-from ._common import mk_context, url_prod
+from ._common import is_session_not_found, mk_context, url_prod
 
 
 class AsyncClient:
     _client: simple_api_twirp_async.AsyncSimpleClient
     _api_client: api_twirp_async.AsyncEvalClient
+    _session_mgr: session_twirp_async.AsyncSessionManagerClient
     _timeout: float
     _sesh: session_pb2.Session
     _session_id: str | None
@@ -62,6 +64,12 @@ class AsyncClient:
             server_path_prefix=server_path_prefix,
             session=self._session,
         )
+        self._session_mgr = session_twirp_async.AsyncSessionManagerClient(
+            url,
+            timeout=timeout,
+            server_path_prefix=server_path_prefix,
+            session=self._session,
+        )
         self._timeout = timeout
 
     async def __aenter__(self, *_: Any) -> AsyncClient:
@@ -84,10 +92,26 @@ class AsyncClient:
                 else:
                     raise ex
         else:
-            # TODO: actually re-open session via RPC
-            self._sesh = session_pb2.Session(
-                id=self._session_id,
-            )
+            self._sesh = session_pb2.Session(id=self._session_id)
+            try:
+                await self._session_mgr.open_session(
+                    ctx=self.mk_context(),
+                    request=session_pb2.SessionOpen(
+                        id=self._sesh,
+                        api_version=api_types_version.api_types_version,
+                    ),
+                )
+            except TwirpServerException as ex:
+                if is_session_not_found(ex):
+                    self._sesh = await self._client.create_session(
+                        ctx=self.mk_context(),
+                        request=simple_api_pb2.SessionCreateReq(
+                            api_version=api_types_version.api_types_version
+                        ),
+                    )
+                    self._session_id = self._sesh.id
+                else:
+                    raise
         return self
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:

--- a/src/py/client/_common.py
+++ b/src/py/client/_common.py
@@ -1,5 +1,6 @@
 from .. import api_types_version
 from ..twirp.context import Context
+from ..twirp.exceptions import TwirpServerException
 
 url_dev = "https://api.dev.imandracapital.com/internal/imandrax/"
 url_prod = "https://api.imandra.ai/internal/imandrax/"
@@ -8,3 +9,16 @@ url_prod = "https://api.imandra.ai/internal/imandrax/"
 def mk_context() -> Context:
     """Build a request context with the appropriate headers"""
     return Context(headers={"x-api-version": api_types_version.api_types_version})
+
+
+def is_session_not_found(ex: TwirpServerException) -> bool:
+    # TODO:
+    # The server currently surfaces an expired/missing session as a generic
+    # internal error; the only stable signal is the substring in the body
+    # message. The phrasing differs between RPCs:
+    #   - SessionManager.open_session  -> "Unknown session"
+    #   - other session-bearing RPCs   -> "Session not found"
+    # Replace with a typed code check once the server is updated.
+    body = (getattr(ex, "meta", None) or {}).get("body") or {}  # type: ignore
+    msg = body.get("msg") or ""  # type: ignore
+    return "Session not found" in msg or "Unknown session" in msg


### PR DESCRIPTION
closes #159 on client side

Note: #159 points out a server side issue that the session not found error is returned untyped (as `GeneraIOError`) containing ocaml trace. I think this should be fixed as well