### PR TITLE
py/client: include cloud-prod test in pre-release test

### DIFF
--- a/src/py/Makefile
+++ b/src/py/Makefile
@@ -26,6 +26,7 @@ pre-release-test: build  # Run pre-release tests with built wheel
 	@WHEEL=$$(ls dist/imandrax_api-*.whl | head -n 1); \
 	echo "Using wheel: $$WHEEL"; \
 	uv run --isolated --no-project --with "$$WHEEL" python ../../tests/api/py/test_cloud_dev.py && \
+	uv run --isolated --no-project --with "$$WHEEL" python ../../tests/api/py/test1_cloud_prod.py && \
 	uv run --isolated --no-project --with "$$WHEEL" python ../../tests/api/py/test_extract_region_str.py
 
 test-setup-py-install:


### PR DESCRIPTION
To make sure we never release an API library without the service being live


Note: we should turn `tests/py` into proper pytest and wire it up in publish-related Make targets.