### PR TITLE
client/py: Add decompose compute timeout

### DIFF
--- a/src/py/client/__init__.py
+++ b/src/py/client/__init__.py
@@ -171,8 +171,18 @@ class Client:
         lift_bool: Optional[simple_api_pb2.LiftBool] = None,
         timeout: Optional[float] = None,
         string_results: Optional[bool] = None,
+        compute_timeout: Optional[int] = None,
     ) -> simple_api_pb2.DecomposeRes:
-        timeout = timeout or self._timeout
+        """
+        Args:
+            timeout (float | None): HTTP request timeout, coerced to `compute_timeout + 10`
+                if `compute_timeout` is smaller than `timeout`
+            compute_timeout (int | None): region decomposition timeout (in seconds) on the server
+        """
+        if timeout is None:
+            timeout = self._timeout
+        if compute_timeout is not None:
+            timeout = max(timeout, compute_timeout + 10)
 
         req = simple_api_pb2.DecomposeReq(
             name=name,
@@ -189,6 +199,8 @@ class Client:
             req.ctx_simp = ctx_simp
         if string_results is not None:
             req.string_results = string_results
+        if compute_timeout is not None:
+            req.timeout = compute_timeout
 
         return self._client.decompose(
             ctx=self.mk_context(),

--- a/src/py/client/__init__.py
+++ b/src/py/client/__init__.py
@@ -175,14 +175,11 @@ class Client:
     ) -> simple_api_pb2.DecomposeRes:
         """
         Args:
-            timeout (float | None): HTTP request timeout, coerced to `compute_timeout + 10`
-                if `compute_timeout` is smaller than `timeout`
-            compute_timeout (int | None): region decomposition timeout (in seconds) on the server
+            timeout (float | None): HTTP request timeout
+            compute_timeout (int | None): computation timeout (in seconds) on the server
         """
         if timeout is None:
             timeout = self._timeout
-        if compute_timeout is not None:
-            timeout = max(timeout, compute_timeout + 10)
 
         req = simple_api_pb2.DecomposeReq(
             name=name,

--- a/src/py/client/_async.py
+++ b/src/py/client/_async.py
@@ -154,14 +154,11 @@ class AsyncClient:
     ) -> simple_api_pb2.DecomposeRes:
         """
         Args:
-            timeout (float | None): HTTP request timeout, coerced to `compute_timeout + 10`
-                if `compute_timeout` is smaller than `timeout`
-            compute_timeout (int | None): region decomposition timeout (in seconds) on the server
+            timeout (float | None): HTTP request timeout
+            compute_timeout (int | None): computation timeout (in seconds) on the server
         """
         if timeout is None:
             timeout = self._timeout
-        if compute_timeout is not None:
-            timeout = max(timeout, compute_timeout + 10)
 
         req = simple_api_pb2.DecomposeReq(
             name=name,

--- a/src/py/client/_async.py
+++ b/src/py/client/_async.py
@@ -150,8 +150,18 @@ class AsyncClient:
         lift_bool: Optional[simple_api_pb2.LiftBool] = None,
         timeout: Optional[float] = None,
         string_results: Optional[bool] = None,
+        compute_timeout: Optional[int] = None,
     ) -> simple_api_pb2.DecomposeRes:
-        timeout = timeout or self._timeout
+        """
+        Args:
+            timeout (float | None): HTTP request timeout, coerced to `compute_timeout + 10`
+                if `compute_timeout` is smaller than `timeout`
+            compute_timeout (int | None): region decomposition timeout (in seconds) on the server
+        """
+        if timeout is None:
+            timeout = self._timeout
+        if compute_timeout is not None:
+            timeout = max(timeout, compute_timeout + 10)
 
         req = simple_api_pb2.DecomposeReq(
             name=name,
@@ -168,6 +178,8 @@ class AsyncClient:
             req.ctx_simp = ctx_simp
         if string_results is not None:
             req.string_results = string_results
+        if compute_timeout is not None:
+            req.timeout = compute_timeout
 
         return await self._client.decompose(
             ctx=self.mk_context(),


### PR DESCRIPTION
Issue: We only have a http request timeout for the client and the compute timeout attached to a specific decomp request[^1]. The latter cannot be set.

This PR adds that parameter.

---

[^1]:
https://github.com/imandra-ai/imandrax-api/blob/3ed3e511de3dc7e0be1e5774b9426539b6ac65ed/src/proto/simple_api.proto#L72-L94